### PR TITLE
Add WP 5.2 wp_body_open to header.php

### DIFF
--- a/src/header.php
+++ b/src/header.php
@@ -29,6 +29,10 @@
 
 <body <?php body_class(); ?>>
 
+  <?php if ( function_exists( 'wp_body_open' ) ) {
+  	wp_body_open();
+  } ?>
+
   <?php // Header ?>
   <header>
 


### PR DESCRIPTION
This adds the backward-compatible `wp-body-open` hook from this comment: https://make.wordpress.org/themes/2019/03/29/addition-of-new-wp_body_open-hook/#comment-43714